### PR TITLE
Fix sdb script when mono PATH has whitespaces

### DIFF
--- a/sdb.in
+++ b/sdb.in
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-MONO_PATH=`dirname $0`:$MONO_PATH exec `which mono` __MONO_OPTIONS__ $MONO_OPTIONS `dirname $0`/sdb.exe "$@"
+MONO_PATH=`dirname $0`:$MONO_PATH exec "`which mono`" __MONO_OPTIONS__ $MONO_OPTIONS `dirname $0`/sdb.exe "$@"


### PR DESCRIPTION
For example on Windows, `which mono` returns a PATH with whitespaces:

    /C/Program Files (x86)/Mono-3.2.3/bin/mono

Hence running the script `sdb` fails with

    ./bin/sdb: line 2: exec: /C/Program: cannot execute: No such file or directory