### PR TITLE
Fix 'step into' / 'step over' command mixup

### DIFF
--- a/src/Debugger.cs
+++ b/src/Debugger.cs
@@ -520,7 +520,7 @@ namespace Mono.Debugger.Client
             {
                 if (_session != null && !_session.IsRunning && !_session.HasExited)
                 {
-                    _session.StepLine();
+                    _session.NextLine();
 
                     CommandLine.InferiorExecuting = true;
                 }
@@ -533,7 +533,7 @@ namespace Mono.Debugger.Client
             {
                 if (_session != null && !_session.IsRunning && !_session.HasExited)
                 {
-                    _session.StepInstruction();
+                    _session.NextInstruction();
 
                     CommandLine.InferiorExecuting = true;
                 }
@@ -546,7 +546,7 @@ namespace Mono.Debugger.Client
             {
                 if (_session != null && !_session.IsRunning && !_session.HasExited)
                 {
-                    _session.NextLine();
+                    _session.StepLine();
 
                     CommandLine.InferiorExecuting = true;
                 }
@@ -559,7 +559,7 @@ namespace Mono.Debugger.Client
             {
                 if (_session != null && !_session.IsRunning && !_session.HasExited)
                 {
-                    _session.NextInstruction();
+                    _session.StepInstruction();
 
                     CommandLine.InferiorExecuting = true;
                 }


### PR DESCRIPTION
From Mono.Debugging/Mono.Debugging.Client/DebuggerSession.cs

// Executes one line of code
public void NextLine ()

// Executes one line of code, stepping into method invocations
public void StepLine ()

However, sdb's 'step over line' and 'step into line' commands called
'StepLine()' and 'NextLine()' respectively, hence a straight switch
was needed

'StepInstruction/NextInstruction' usage needed the same correction